### PR TITLE
Add host to opengraph image tag

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -7,7 +7,7 @@
     {{ block "open-graph" . }}
     <meta property="og:title" content="{{ .Title }}" />
     <meta property="og:description" content="{{ .Site.Params.homepage.description }}" />
-    <meta property="og:image" content="open-graph/homepage.png" />
+    <meta property="og:image" content="https://antoniopantaleo.dev/open-graph/homepage.png" />
     {{ end }}
     <title>
       {{ block "title" . }} {{- .Title }} - {{ .Site.Title -}} {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -6,7 +6,7 @@
 {{ $quote := replaceRE "^---(.|\n)*?---" "" $firstPart }}
 <meta property="og:title" content="{{ .Title }}" />
 <meta property="og:description" content="{{ $quote }}" />
-<meta property="og:image" content="{{ printf " open-graph/%s.png" .File.BaseFileName }}" />
+<meta property="og:image" content="{{ printf "https://antoniopantaleo.dev/open-graph/%s.png" .File.BaseFileName }}" />
 {{end }}
 
 {{ define "main" }}


### PR DESCRIPTION
This pull request updates the Open Graph image URLs to use absolute paths instead of relative paths. This ensures that the images are correctly displayed when shared on social media platforms.

Changes to Open Graph image URLs:

* [`layouts/_default/baseof.html`](diffhunk://#diff-ec6e7cb6e89cbe10d49085811bd67ad23df375247295fc387da90f5fdc56de7fL10-R10): Updated the `og:image` meta tag to use an absolute URL for the homepage Open Graph image.
* [`layouts/_default/single.html`](diffhunk://#diff-b2ff2a8d1f2a8a15c65288757c8b9acde7bec0ef491acb8048f1ddb61985cc41L9-R9): Updated the `og:image` meta tag to use an absolute URL for individual page Open Graph images.